### PR TITLE
Allow loading custom changelog from artifacts with correct encoding

### DIFF
--- a/src/main/java/com/testfairy/uploader/Uploader.java
+++ b/src/main/java/com/testfairy/uploader/Uploader.java
@@ -28,6 +28,7 @@ import org.jenkinsci.plugins.testfairy.TestFairyBaseRecorder;
 import org.jenkinsci.plugins.testfairy.Utils;
 
 import java.io.*;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Scanner;
 
@@ -189,7 +190,7 @@ public class Uploader {
 		addFileEntity(entity, "proguard_file", mappingFile);
 
 		addEntity(entity, "api_key",  recorder.getApiKey());
-		addEntity(entity, "changelog",  changeLog);
+		addEntity(entity, "changelog",  changeLog, Charset.defaultCharset());
 		addEntity(entity, "video-quality",  recorder.getVideoQuality()); // if omitted, default value is "high"
 		addEntity(entity, "screenshot-interval",  recorder.getScreenshotInterval()); // if omitted, default is 1 frame per second (videoRate = 1.0)
 		addEntity(entity, "max-duration",  recorder.getMaxDuration()); // override default value
@@ -215,9 +216,13 @@ public class Uploader {
 	}
 
 	private void addEntity(MultipartEntity entity, String name, String value) throws UnsupportedEncodingException {
+		addEntity(entity, name, value, null);
+	}
+
+	private void addEntity(MultipartEntity entity, String name, String value, Charset charset) throws UnsupportedEncodingException {
 		if (value != null && !value.isEmpty()) {
 			logger.println("--add " +name + ": " + (name.contentEquals("api_key") ? "****" : value.replace("\n", "")));
-			entity.addPart(name, new StringBody(value));
+			entity.addPart(name, new StringBody(value, charset));
 		}
 	}
 

--- a/src/main/java/org/jenkinsci/plugins/testfairy/TestFairyAndroidRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/testfairy/TestFairyAndroidRecorder.java
@@ -81,7 +81,7 @@ public class TestFairyAndroidRecorder extends TestFairyBaseRecorder {
 		listener.getLogger().println("TestFairy Uploader (Deprecated)... v " + Utils.getVersion(getClass()) + ", run on " + getHostName());
 		try {
 			EnvVars vars = build.getEnvironment(listener);
-			String changeLog = Utils.extractChangeLog(vars, build.getChangeSet(), listener.getLogger());
+			String changeLog = Utils.extractChangeLog(build, vars, build.getChangeSet(), listener.getLogger());
 			AndroidBuildEnvironment environment = getDescriptor().getEnvironment(launcher);
 
 			try {

--- a/src/main/java/org/jenkinsci/plugins/testfairy/TestFairyIosRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/testfairy/TestFairyIosRecorder.java
@@ -53,7 +53,7 @@ public class TestFairyIosRecorder extends TestFairyBaseRecorder {
 		listener.getLogger().println("TestFairy iOS/Android Uploader... v " + Utils.getVersion(getClass()) + ", run on " + getHostName());
 		try {
 			EnvVars vars = build.getEnvironment(listener);
-			String changeLog = Utils.extractChangeLog(vars, build.getChangeSet(), listener.getLogger());
+			String changeLog = Utils.extractChangeLog(build, vars, build.getChangeSet(), listener.getLogger());
 
 			try {
 				launcher.getChannel().call(new IosRemoteRecorder(listener, this, vars, changeLog));


### PR DESCRIPTION
From https://plugins.jenkins.io/TestFairy/

```
Custom changelog
In order to add your own changelog or comments, please create a text file in the following location: $JENKINS_HOME/jobs/$JOB_NAME/builds/$BUILD_ID/testfairy_change_log

The content of this file will override the default changelog
```
That logic not works as expected due:
 * accessing jenkins system dir - will not work correct  on nodes
 * need some special action for copy to this directory (like call bash or cmd)

This change allow use testfairy_change_log from artifacts (need call Archive the Artifacts with testfairy_change_log before TestFairy Upload). Also it fix charset issue - file can be not only in ASCII charset.

Thanks