### PR TITLE
Move documentation into the GitHub repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>TestFairy</artifactId>
     <name>TestFairy Plugin</name>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/TestFairy+Plugin</url>
+    <url>https://github.com/jenkinsci/testfairy-plugin</url>
     <version>${revision}-${changelist}</version>
     <packaging>hpi</packaging>
 


### PR DESCRIPTION
As requested in https://issues.jenkins.io/browse/INFRA-3176 and in https://github.com/jenkins-infra/helpdesk/issues/2717, this change will cause the documentation for the plugin on https://plugins.jenkins.io/TestFairy/ to be taken from the GitHub repository.

The change will happen after the first release of the plugin that includes this commit.

https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/ describes the transition process

https://www.jenkins.io/doc/developer/publishing/documentation/#documenting-plugins also describes the transition process

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
